### PR TITLE
Make Template::Liquid->render() respect a preexisting context

### DIFF
--- a/lib/Template/Liquid.pm
+++ b/lib/Template/Liquid.pm
@@ -47,9 +47,20 @@ sub parse {
 
 sub render {
     my ($s, %assigns) = @_;
-    $s->{context} = Template::Liquid::Context->new(template => $s, assigns => \%assigns);
-    return $s->{document}->render();
+    if( ! $s->{context}) {
+        $s->{context} = Template::Liquid::Context->new(template => $s, assigns => \%assigns);
+        $result = $s->{document}->render();
+    } else {
+        # This is quite similar to $s->{context}->block(), but
+        # we want %assigns to override what is currently in the scope
+        my $old_scope = $s->{context}->{scopes}->[-1];
+        $s->{context}->push({ %$old_scope, %assigns });
+        $result = $s->{document}->render();
+        $s->{context}->pop;
+    };
+    return $result;
 }
+
 1;
 
 =pod

--- a/t/0300_basics/03002_render_context.t
+++ b/t/0300_basics/03002_render_context.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use lib qw[../../lib ../../blib/lib];
+use Test::More;    # Requires 0.94 as noted in Build.PL
+use Template::Liquid;
+#
+my $template = Template::Liquid->parse('{{foo}}');
+$template->{context} = Template::Liquid::Context->new( assigns => { foo => 'bar' });
+is $template->render(), 'bar', 'We can set up a pre-existing context';
+is $template->render(foo=>'override'), 'override', '... and directly passed arguments override that';
+is $template->render(), 'bar', "... and we don't overwrite stuff permanently";
+
+$template = Template::Liquid->parse('{{foo}}');
+is $template->render(foo=>'without context'), 'without context', '... and not having a context still works as expected';
+
+done_testing();


### PR DESCRIPTION
This is mostly to make Template::LiquidX::Tag::Include actually work. This should close https://github.com/sanko/Template-LiquidX-Tag-Include/issues/1 , as rendering variables then magically works.

I've also added a test that documents how I think things should behave...