### PR TITLE
For limit modified

### DIFF
--- a/lib/Template/Liquid.pm
+++ b/lib/Template/Liquid.pm
@@ -47,9 +47,20 @@ sub parse {
 
 sub render {
     my ($s, %assigns) = @_;
-    $s->{context} = Template::Liquid::Context->new(template => $s, assigns => \%assigns);
-    return $s->{document}->render();
+    if( ! $s->{context}) {
+        $s->{context} = Template::Liquid::Context->new(template => $s, assigns => \%assigns);
+        $result = $s->{document}->render();
+    } else {
+        # This is quite similar to $s->{context}->block(), but
+        # we want %assigns to override what is currently in the scope
+        my $old_scope = $s->{context}->{scopes}->[-1];
+        $s->{context}->push({ %$old_scope, %assigns });
+        $result = $s->{document}->render();
+        $s->{context}->pop;
+    };
+    return $result;
 }
+
 1;
 
 =pod

--- a/lib/Template/Liquid/Tag/For.pm
+++ b/lib/Template/Liquid/Tag/For.pm
@@ -113,7 +113,7 @@ sub render {
                    : $#$list
         );
         $max    = $#$list if $max > $#$list;
-        @$list  = @{$list}[$min .. $max];
+        $list  = [@{$list}[$min .. $max]]; # make a copy so we can use the list again
         @$list  = reverse @$list if $reversed;
         $limit  = defined $limit ? $limit : scalar @$list;
         $offset = defined $offset ? $offset : 0;

--- a/t/0200_tags/02001_for_limit.t
+++ b/t/0200_tags/02001_for_limit.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use lib qw[../../lib ../../blib/lib];
+use Test::More;    # Requires 0.94 as noted in Build.PL
+use Template::Liquid;
+use Data::Dumper;
+plan tests => 2;
+
+my $template = Template::Liquid->parse(<<'TEMPLATE');
+First: {% for post in posts limit:1 %}{{ post }}{% endfor %}
+---
+{% for post in posts limit:10 %}{{post}},{% endfor %}
+TEMPLATE
+
+my @list = qw( 1 2 3 4 5 6 7 8 9 10 11 );
+
+my $result = $template->render( posts => \@list );
+
+is $result, << 'RESULT', "We render the expected list";
+First: 1
+---
+1,2,3,4,5,6,7,8,9,10,
+RESULT
+
+# This is a half-truth. Of course, Template::Liquid is allowed to modify the
+# list passed in, but it should still contain the original number of elements
+# so other template parts can still access that.
+is 0+@list, 11, "The original list remains unmodified"
+    or diag Dumper \@list;

--- a/t/0300_basics/03002_render_context.t
+++ b/t/0300_basics/03002_render_context.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use lib qw[../../lib ../../blib/lib];
+use Test::More;    # Requires 0.94 as noted in Build.PL
+use Template::Liquid;
+#
+my $template = Template::Liquid->parse('{{foo}}');
+$template->{context} = Template::Liquid::Context->new( assigns => { foo => 'bar' });
+is $template->render(), 'bar', 'We can set up a pre-existing context';
+is $template->render(foo=>'override'), 'override', '... and directly passed arguments override that';
+is $template->render(), 'bar', "... and we don't overwrite stuff permanently";
+
+$template = Template::Liquid->parse('{{foo}}');
+is $template->render(foo=>'without context'), 'without context', '... and not having a context still works as expected';
+
+done_testing();


### PR DESCRIPTION
This fixes a bug where using a :limit attribute would truncate a list:

```
First: {% for post in posts limit:1 %}{{ post }}{% endfor %}
---
{% for post in posts limit:10 %}{{post}},{% endfor %}
```

The above will only render the first element of the list in both loops, instead of rendering the single element as the first loop, and elements 1 to 10 in the second loop.