### PR TITLE
This fixes https://github.com/sanko/template-liquid/issues/14

### DIFF
--- a/lib/Template/Liquid/Block.pm
+++ b/lib/Template/Liquid/Block.pm
@@ -4,6 +4,7 @@ require Template::Liquid::Error;
 use base 'Template::Liquid::Document';
 use strict;
 use warnings;
+use Data::Dumper;
 
 sub new {
     my ($class, $args) = @_;
@@ -34,14 +35,14 @@ sub new {
     }, $class;
     $s->{'conditions'} = (
         $args->{'tag_name'} eq 'else' ? [1] : sub {    # Oh, what a mess...
-            my @conditions = split m[\s+\b(and|or)\b\s+]o,
+	    my @conditions = split m/(?:\s+\b(and|or)\b\s+)(?![^"]*"(?:[^"]*"[^"]*")*[^"]*$)/o,
                 $args->{parent}->{tag_name} eq 'for'
                 ? 1
                 : (defined $args->{'attrs'} ? $args->{'attrs'} : '');
             my @equality;
             while (my $x = shift @conditions) {
                 push @equality, (
-                    $x =~ m[\b(?:and|or)\b]o           # XXX - ARG
+                    $x =~ m/(?:\b(and|or)\b)(?![^"]*"(?:[^"]*"[^"]*")*[^"]*$)/o
                     ? bless({template  => $args->{'template'},
                              parent    => $s,
                              condition => $x,

--- a/lib/Template/Liquid/Block.pm
+++ b/lib/Template/Liquid/Block.pm
@@ -4,7 +4,6 @@ require Template::Liquid::Error;
 use base 'Template::Liquid::Document';
 use strict;
 use warnings;
-use Data::Dumper;
 
 sub new {
     my ($class, $args) = @_;

--- a/lib/Template/Liquid/Document.pm
+++ b/lib/Template/Liquid/Document.pm
@@ -126,6 +126,7 @@ NODE: while (my $token = shift @{$tokens}) {
 sub render {
     my ($s) = @_;
     my $return = '';
+#    print STDERR "DEBUG RENDERING NODE\n";
     for my $node (@{$s->{'nodelist'}}) {
         my $rendering = ref $node ? $node->render() : $node;
         $return .= defined $rendering ? $rendering : '';

--- a/t/0200_tags/02006_if.t
+++ b/t/0200_tags/02006_if.t
@@ -211,7 +211,7 @@ INPUT
 
 EXPECTED
 is( Template::Liquid->parse(
-        <<'INPUT')->render(), <<'EXPECTED', 'compound condition with and/or in quotes if [A] (myvar == "foo and bar")');
+        <<'INPUT')->render(), <<'EXPECTED', 'condition with and/or in quotes if [A] (myvar == "foo and bar")');
 {% assign myvar = "foo and bar" %}{% if myvar == "foo and bar" %}
     foo and bar
 {% else %}
@@ -220,6 +220,55 @@ is( Template::Liquid->parse(
 INPUT
 
     foo and bar
+
+EXPECTED
+is( Template::Liquid->parse(
+        <<'INPUT')->render(), <<'EXPECTED', 'compound condition with "and" in quotes if [A] (myvar == "foo and bar" and 5 > 1)');
+{% assign myvar = "foo and bar" %}{% if myvar == "foo and bar" and 5 > 1 %}
+    foo and bar
+{% else %}
+    Not foo and bar
+{% endif %}
+INPUT
+
+    foo and bar
+
+EXPECTED
+is( Template::Liquid->parse(
+        <<'INPUT')->render(), <<'EXPECTED', 'compound condition with "and" in quotes if [A] (myvar == "foo and bar" and 5 < 1)');
+{% assign myvar = "foo and bar" %}{% if myvar == "foo and bar" and 5 < 1 %}
+    foo and bar
+{% else %}
+    Not foo and bar
+{% endif %}
+INPUT
+
+    Not foo and bar
+
+EXPECTED
+
+is( Template::Liquid->parse(
+        <<'INPUT')->render(), <<'EXPECTED', 'compound condition with "or" in quotes if [A] (myvar == "foo or bar" and 5 > 1)');
+{% assign myvar = "foo or bar" %}{% if myvar == "foo or bar" and 5 > 1 %}
+    foo or bar
+{% else %}
+    Not foo or bar
+{% endif %}
+INPUT
+
+    foo or bar
+
+EXPECTED
+is( Template::Liquid->parse(
+        <<'INPUT')->render(), <<'EXPECTED', 'compound condition with "or" in quotes if [A] (myvar == "foo or bar" and 5 < 1)');
+{% assign myvar = "foo or bar" %}{% if myvar == "foo or bar" and 5 < 1 %}
+    foo or bar
+{% else %}
+    Not foo or bar
+{% endif %}
+INPUT
+
+    Not foo or bar
 
 EXPECTED
 

--- a/t/0200_tags/02006_if.t
+++ b/t/0200_tags/02006_if.t
@@ -210,6 +210,18 @@ is( Template::Liquid->parse(
 INPUT
 
 EXPECTED
+is( Template::Liquid->parse(
+        <<'INPUT')->render(), <<'EXPECTED', 'compound condition with and/or in quotes if [A] (myvar == "foo and bar")');
+{% assign myvar = "foo and bar" %}{% if myvar == "foo and bar" %}
+    foo and bar
+{% else %}
+    Not foo and bar
+{% endif %}
+INPUT
+
+    foo and bar
+
+EXPECTED
 
 # I'm finished
 done_testing();


### PR DESCRIPTION
I fixed the regex to check for surrounding quotation marks so that string literals that contain the word `and` or `or` don't cause parsing errors.