### PR TITLE
fixed up https://github.com/sanko/template-liquid/issues/20

### DIFF
--- a/lib/Template/Liquid/Condition.pm
+++ b/lib/Template/Liquid/Condition.pm
@@ -24,7 +24,7 @@ sub new {
         if !defined $args->{'parent'};
     my ($lval, $condition, $rval)
         = ((defined $args->{'attrs'} ? $args->{'attrs'} : '')
-           =~ m[("[^"]+"|'[^']+'|(?:[\S]+))]go);
+          =~ m[("[^"]+"|'[^']+'|(?:eq|==|ne|!=|lt|<|gt|>|contains|&&|\|\|)|(?:[\w.]+))]go);
     if (defined $lval) {
         if (!defined $rval && !defined $condition) {
             return

--- a/lib/Template/Liquid/Condition.pm
+++ b/lib/Template/Liquid/Condition.pm
@@ -134,7 +134,7 @@ sub gt {
             : $l > $r
         : 0;
 }
-sub lt { return !$_[0]->gt }
+sub lt { return (!$_[0]->gt && !$_[0]->eq) }
 
 sub contains {
     my ($s) = @_;

--- a/lib/Template/Liquid/Tag/For.pm
+++ b/lib/Template/Liquid/Tag/For.pm
@@ -109,7 +109,16 @@ sub render {
             $a =~ m[^\d+$] && $b =~ m[^\d+$] ? ($a <=> $b) : ($a cmp $b)
         } @$list;
     }
-    if (!defined $list || !$list || !@$list) {
+    if (! eval { \@$list } ) {
+        # list is a string
+        $list = [$list];
+    }
+    elsif(ref($list) eq 'ARRAY' && !@$list){
+        # empty array
+        $_undef_list = 1;
+        $list        = [1];
+    }
+    elsif (!defined $list || !$list) {
         $_undef_list = 1;
         $list        = [1];
     }

--- a/t/0200_tags/02001_for.t
+++ b/t/0200_tags/02001_for.t
@@ -3,8 +3,21 @@ use warnings;
 use lib qw[../../lib ../../blib/lib];
 use Test::More;    # Requires 0.94 as noted in Build.PL
 use Template::Liquid;
+#{% assign items = "foo"%}{%for item in items%}{{item}}{%endfor%}
 $|++;
 #
+is( Template::Liquid->parse(
+                    <<'TEMPLATE')->render(array => "foo,bar"), <<'EXPECTED', 'string split');
+{% assign items = array | split: ","  %}{%for item in items%}{{item}}{%endfor%}
+TEMPLATE
+foobar
+EXPECTED
+is( Template::Liquid->parse(
+                    <<'TEMPLATE')->render(array => "foo"), <<'EXPECTED', 'plain string');
+{% assign items = array %}{%for item in items%}{{item}}{%endfor%}
+TEMPLATE
+foo
+EXPECTED
 is(Template::Liquid->parse(<<'TEMPLATE')->render(), <<'EXPECTED', '(1..5)');
 {%for x in (1..5) %}X{%endfor%}
 TEMPLATE

--- a/t/0200_tags/02006_if.t
+++ b/t/0200_tags/02006_if.t
@@ -5,6 +5,21 @@ use Test::More;    # Requires 0.94 as noted in Build.PL
 use Template::Liquid;
 
 # Various condition types
+is(Template::Liquid->parse(<<'INPUT')->render(), <<'EXPECTED', '1==1');
+{% if 1==1 %}One equals one{% endif %}
+INPUT
+One equals one
+EXPECTED
+is(Template::Liquid->parse(<<'INPUT')->render(), <<'EXPECTED', '1== 1');
+{% if 1== 1 %}One equals one{% endif %}
+INPUT
+One equals one
+EXPECTED
+is(Template::Liquid->parse(<<'INPUT')->render(), <<'EXPECTED', '1 ==1');
+{% if 1 ==1 %}One equals one{% endif %}
+INPUT
+One equals one
+EXPECTED
 is(Template::Liquid->parse(<<'INPUT')->render(), <<'EXPECTED', '1 == 1');
 {% if 1 == 1 %}One equals one{% endif %}
 INPUT
@@ -52,6 +67,24 @@ EXPECTED
 is( Template::Liquid->parse(
         <<'INPUT')->render(), <<'EXPECTED', q['This string' != 'some other string']);
 {% if 'This string' != 'some other string' %}Yep.{% endif %}
+INPUT
+Yep.
+EXPECTED
+is( Template::Liquid->parse(
+        <<'INPUT')->render(), <<'EXPECTED', q['This string'!='some other string']);
+{%if 'This string'!='some other string' %}Yep.{%endif%}
+INPUT
+Yep.
+EXPECTED
+is( Template::Liquid->parse(
+        <<'INPUT')->render(), <<'EXPECTED', q['This string' !='some other string']);
+{%if 'This string' !='some other string' %}Yep.{%endif%}
+INPUT
+Yep.
+EXPECTED
+is( Template::Liquid->parse(
+        <<'INPUT')->render(), <<'EXPECTED', q['This string'!=  'some other string']);
+{%if 'This string'!=  'some other string' %}Yep.{%endif%}
 INPUT
 Yep.
 EXPECTED

--- a/t/0500_bugs/05007_less_than_condition.t
+++ b/t/0500_bugs/05007_less_than_condition.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use lib qw[../../lib ../../blib/lib];
+use Test::More;    # Requires 0.94 as noted in Build.PL
+use Template::Liquid;
+#
+my $template = Template::Liquid->parse(
+                      '{%if 10 < 10%}less{%else%}gte{%endif%}');
+is $template->render(),  'gte';
+
+
+$template = Template::Liquid->parse(
+                      '{%if balance < 10%}less{%else%}gte{%endif%}');
+is $template->render(balance => 10),  'gte';
+is $template->render(balance => 0),  'less';
+is $template->render(balance => 11),  'gte';
+#
+done_testing();


### PR DESCRIPTION
Hi,  this code modifies how conditions are parsed to handle valid Liquid syntax that is currently failing in the released version of the module.

This may also fix floating point number comparisons as well.